### PR TITLE
Client v2

### DIFF
--- a/cmd/client/app/commands/config/config.go
+++ b/cmd/client/app/commands/config/config.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/sbilibin2017/gophkeeper/internal/configs"
+	"github.com/sbilibin2017/gophkeeper/internal/configs/clients"
+	"github.com/sbilibin2017/gophkeeper/internal/configs/scheme"
+)
+
+func NewConfig(
+	authURL string,
+	tlsClientCert string,
+	tlsClientKey string,
+) (*configs.ClientConfig, error) {
+	var opts []configs.ClientConfigOpt
+
+	opts = append(opts, configs.WithClientConfigDB())
+
+	schm := scheme.GetSchemeFromURL(authURL)
+
+	switch schm {
+	case scheme.HTTP, scheme.HTTPS:
+		httpOpts := []clients.HTTPClientOption{}
+		if tlsClientCert != "" && tlsClientKey != "" {
+			httpOpts = append(httpOpts, clients.WithHTTPTLSClientCert(tlsClientCert, tlsClientKey))
+		}
+		opts = append(opts, configs.WithClientConfigHTTPClient(authURL, httpOpts...))
+
+	case scheme.GRPC:
+		grpcOpts := []clients.GRPCClientOption{}
+		if tlsClientCert != "" && tlsClientKey != "" {
+			grpcOpts = append(grpcOpts, clients.WithGRPCTLSClientCert(tlsClientCert, tlsClientKey))
+		}
+		opts = append(opts, configs.WithClientConfigGRPCClient(authURL, grpcOpts...))
+
+	default:
+		return nil, errors.New("unsupported scheme: " + schm)
+	}
+
+	return configs.NewClientConfig(opts...)
+}

--- a/cmd/client/app/commands/config/config_test.go
+++ b/cmd/client/app/commands/config/config_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sbilibin2017/gophkeeper/internal/configs/scheme"
+)
+
+// GenerateSelfSignedCert creates temp cert and key files and returns their paths.
+func generateTempCertFiles(t *testing.T) (certPath, keyPath string) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privKey.PublicKey, privKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privKey)})
+
+	tmpCertFile, err := ioutil.TempFile("", "cert-*.pem")
+	require.NoError(t, err)
+	_, err = tmpCertFile.Write(certPEM)
+	require.NoError(t, err)
+	err = tmpCertFile.Close()
+	require.NoError(t, err)
+
+	tmpKeyFile, err := ioutil.TempFile("", "key-*.pem")
+	require.NoError(t, err)
+	_, err = tmpKeyFile.Write(keyPEM)
+	require.NoError(t, err)
+	err = tmpKeyFile.Close()
+	require.NoError(t, err)
+
+	return tmpCertFile.Name(), tmpKeyFile.Name()
+}
+
+func TestNewConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		authURL        string
+		tlsCert        string
+		tlsKey         string
+		expectedScheme string
+		expectError    bool
+	}{
+		{
+			name:           "HTTP scheme no TLS",
+			authURL:        "http://example.com",
+			tlsCert:        "",
+			tlsKey:         "",
+			expectedScheme: scheme.HTTP,
+			expectError:    false,
+		},
+		{
+			name:           "HTTPS scheme with TLS",
+			authURL:        "https://example.com",
+			expectedScheme: scheme.HTTPS,
+			expectError:    false,
+		},
+		{
+			name:           "gRPC scheme with TLS",
+			authURL:        "grpc://example.com",
+			expectedScheme: scheme.GRPC,
+			expectError:    false,
+		},
+		{
+			name:        "Unsupported scheme returns error",
+			authURL:     "ftp://example.com",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			// Remove client.db after test, ignore error if file doesn't exist
+			defer func() {
+				_ = os.Remove("client.db")
+			}()
+
+			// Generate TLS cert/key files if needed
+			if !tt.expectError && (tt.expectedScheme == scheme.HTTPS || tt.expectedScheme == scheme.GRPC) {
+				certFile, keyFile := generateTempCertFiles(t)
+				defer os.Remove(certFile)
+				defer os.Remove(keyFile)
+				tt.tlsCert = certFile
+				tt.tlsKey = keyFile
+			}
+
+			cfg, err := NewConfig(tt.authURL, tt.tlsCert, tt.tlsKey)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, cfg)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+
+			// Adjust this check depending on how your config struct exposes clients
+			switch tt.expectedScheme {
+			case scheme.HTTP, scheme.HTTPS:
+				require.NotNil(t, cfg.HTTPClient)
+				require.Nil(t, cfg.GRPCClient)
+			case scheme.GRPC:
+				require.NotNil(t, cfg.GRPCClient)
+				require.Nil(t, cfg.HTTPClient)
+			}
+		})
+	}
+}

--- a/cmd/client/app/commands/login.go
+++ b/cmd/client/app/commands/login.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/sbilibin2017/gophkeeper/cmd/client/app/commands/config"
+	"github.com/sbilibin2017/gophkeeper/internal/client"
+	"github.com/sbilibin2017/gophkeeper/internal/models"
+	pb "github.com/sbilibin2017/gophkeeper/pkg/grpc"
+	"github.com/spf13/cobra"
+)
+
+// RegisterLoginCommand registers the "login" command to the root cobra command.
+// The "login" command authenticates a user by username and password using either HTTP or gRPC.
+// It validates inputs, prepares the client configuration, ensures necessary DB tables exist,
+// then sends the authentication request. On success, it prints the authentication token.
+//
+// Usage:
+//
+//	login --username USERNAME --password PASSWORD --auth-url URL [--tls-client-cert PATH]
+//
+// Example:
+//
+//	gophkeeper login --username alice --password 'P@ssw0rd123' --auth-url https://auth.example.com
+func RegisterLoginCommand(root *cobra.Command) {
+	var (
+		username      string
+		password      string
+		authURL       string
+		tlsClientCert string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate user",
+		Long: `Authenticate a user by providing a username and password.
+
+This command validates the credentials, initializes client configuration,
+creates necessary database tables, and sends an authentication request to
+the specified auth service endpoint using HTTP or gRPC protocols.
+
+Upon successful authentication, an authentication token will be printed.`,
+		Example: `  # Authenticate user via HTTP
+  gophkeeper login --username alice --password 'P@ssw0rd123' --auth-url https://auth.example.com
+
+  # Authenticate user with TLS client certificate for secure communication
+  gophkeeper login --username bob --password 'S3cr3t!' --auth-url https://auth.example.com --tls-client-cert /path/to/cert.pem`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Validate username and password for login
+			if err := client.ValidateUsernameLogin(username); err != nil {
+				return fmt.Errorf("invalid username: %w", err)
+			}
+			if err := client.ValidatePasswordLogin(password); err != nil {
+				return fmt.Errorf("invalid password: %w", err)
+			}
+
+			// Create client config (including DB, HTTP/gRPC clients)
+			config, err := config.NewConfig(authURL, tlsClientCert, "")
+			if err != nil {
+				return err
+			}
+
+			// Create required DB tables
+			if err := client.CreateBinaryRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create binary request table: %w", err)
+			}
+			if err := client.CreateTextRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create text request table: %w", err)
+			}
+			if err := client.CreateUsernamePasswordRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create username-password request table: %w", err)
+			}
+			if err := client.CreateBankCardRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create bank card request table: %w", err)
+			}
+
+			req := &models.AuthRequest{
+				Username: username,
+				Password: password,
+			}
+
+			// Use HTTP client if configured
+			if config.HTTPClient != nil {
+				resp, err := client.AuthHTTP(ctx, config.HTTPClient, req)
+				if err != nil {
+					return fmt.Errorf("http login failed: %w", err)
+				}
+				cmd.Println(resp.Token)
+				return nil
+			}
+
+			// Use gRPC client if configured
+			if config.GRPCClient != nil {
+				grpcClient := pb.NewAuthServiceClient(config.GRPCClient)
+				resp, err := client.AuthGRPC(ctx, grpcClient, req)
+				if err != nil {
+					return fmt.Errorf("grpc login failed: %w", err)
+				}
+				cmd.Println(resp.Token)
+				return nil
+			}
+
+			return fmt.Errorf("no HTTP or gRPC client available")
+		},
+	}
+
+	cmd.Flags().StringVar(&username, "username", "", "Username for authentication")
+	cmd.Flags().StringVar(&password, "password", "", "Password for authentication")
+	cmd.Flags().StringVar(&authURL, "auth-url", "", "Authentication service URL")
+	cmd.Flags().StringVar(&tlsClientCert, "tls-client-cert", "", "Path to client TLS certificate file (optional)")
+
+	root.AddCommand(cmd)
+}

--- a/cmd/client/app/commands/register.go
+++ b/cmd/client/app/commands/register.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/sbilibin2017/gophkeeper/cmd/client/app/commands/config"
+	"github.com/sbilibin2017/gophkeeper/internal/client"
+	"github.com/sbilibin2017/gophkeeper/internal/models"
+	pb "github.com/sbilibin2017/gophkeeper/pkg/grpc"
+	"github.com/spf13/cobra"
+)
+
+// RegisterRegisterCommand registers the "register" command to the root command.
+// This command allows a user to register a new account by providing a username and password.
+//
+// Usage:
+//
+//	register --username USERNAME --password PASSWORD --auth-url URL [--tls-client-cert PATH] [--tls-client-key PATH]
+//
+// Example:
+//
+//	gophkeeper register --username alice --password 'P@ssw0rd123' --auth-url https://auth.example.com
+func RegisterRegisterCommand(root *cobra.Command) {
+	var (
+		username      string
+		password      string
+		authURL       string
+		tlsClientCert string
+		tlsClientKey  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a new user",
+		Long: `Register a new user account by providing a username and password.
+
+This command validates the provided credentials according to registration rules,
+sets up the client configuration including HTTP or gRPC clients,
+creates necessary database tables, and sends a registration request to the auth service.
+
+Upon successful registration, an authentication token will be printed.`,
+		Example: `  # Register a new user via HTTP
+  gophkeeper register --username alice --password 'P@ssw0rd123' --auth-url https://auth.example.com
+
+  # Register a new user with TLS client cert and key for secure communication
+  gophkeeper register --username bob --password 'S3cr3t!' --auth-url https://auth.example.com --tls-client-cert /path/to/cert.pem --tls-client-key /path/to/key.pem`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// Validate username and password according to registration rules.
+			if err := client.ValidateRegisterUsername(username); err != nil {
+				return fmt.Errorf("invalid username: %w", err)
+			}
+			if err := client.ValidateRegisterPassword(password); err != nil {
+				return fmt.Errorf("invalid password: %w", err)
+			}
+
+			// Create client configuration including HTTP or gRPC clients.
+			config, err := config.NewConfig(authURL, tlsClientCert, tlsClientKey)
+			if err != nil {
+				return err
+			}
+
+			// Create necessary DB tables after client initialization.
+			if err := client.CreateBinaryRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create binary request table: %w", err)
+			}
+			if err := client.CreateTextRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create text request table: %w", err)
+			}
+			if err := client.CreateUsernamePasswordRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create username-password request table: %w", err)
+			}
+			if err := client.CreateBankCardRequestTable(config.DB); err != nil {
+				return fmt.Errorf("failed to create bank card request table: %w", err)
+			}
+
+			req := &models.AuthRequest{
+				Username: username,
+				Password: password,
+			}
+
+			// Use HTTP client if available
+			if config.HTTPClient != nil {
+				resp, err := client.AuthHTTP(ctx, config.HTTPClient, req)
+				if err != nil {
+					return fmt.Errorf("http register failed: %w", err)
+				}
+				cmd.Println(resp.Token)
+				return nil
+			}
+
+			// Use gRPC client if available
+			if config.GRPCClient != nil {
+				grpcClient := pb.NewAuthServiceClient(config.GRPCClient)
+				resp, err := client.AuthGRPC(ctx, grpcClient, req)
+				if err != nil {
+					return fmt.Errorf("grpc register failed: %w", err)
+				}
+				cmd.Println(resp.Token)
+				return nil
+			}
+
+			return fmt.Errorf("no HTTP or gRPC client available")
+		},
+	}
+
+	cmd.Flags().StringVar(&username, "username", "", "Username for authentication")
+	cmd.Flags().StringVar(&password, "password", "", "Password for authentication")
+	cmd.Flags().StringVar(&authURL, "auth-url", "", "Authentication service URL")
+	cmd.Flags().StringVar(&tlsClientCert, "tls-client-cert", "", "Path to client TLS certificate file (optional)")
+	cmd.Flags().StringVar(&tlsClientKey, "tls-client-key", "", "Path to client TLS key file (optional)")
+
+	root.AddCommand(cmd)
+}

--- a/cmd/client/app/root.go
+++ b/cmd/client/app/root.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"github.com/sbilibin2017/gophkeeper/cmd/client/app/commands"
+	"github.com/spf13/cobra"
+)
+
+// NewRootCommand creates the root CLI command with description.
+func NewRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "gophkeeper",
+		Short: "GophKeeper — a password manager for secure private data storage",
+		Long: `GophKeeper is a client-server system for securely storing
+and managing logins, passwords, bank cards, and other private information.
+
+Available commands allow user registration, authentication,
+working with various secret types (logins, text, binary data, bank cards),
+as well as synchronizing data with the server.`,
+	}
+
+	commands.RegisterRegisterCommand(rootCmd)
+	commands.RegisterLoginCommand(rootCmd)
+
+	commands.RegisterAddBankCardSecretCommand(rootCmd)
+	commands.RegisterAddBinarySecretCommand(rootCmd)
+	commands.RegisterAddTextSecretCommand(rootCmd)
+	commands.RegisterAddUsernamePasswordSecretCommand(rootCmd)
+
+	commands.RegisterGetSecretCommand(rootCmd)
+	commands.RegisterListSecretsCommand(rootCmd)
+	commands.RegisterDeleteSecretCommand(rootCmd)
+
+	commands.RegisterSyncCommand(rootCmd)
+
+	return rootCmd
+}

--- a/cmd/client/app/root_test.go
+++ b/cmd/client/app/root_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRootCommand(t *testing.T) {
+	rootCmd := NewRootCommand()
+
+	assert.NotNil(t, rootCmd, "root command should not be nil")
+	assert.Equal(t, "gophkeeper", rootCmd.Use, "command use should be 'gophkeeper'")
+	assert.Contains(t, rootCmd.Short, "password manager", "short description should mention password manager")
+	assert.Contains(t, rootCmd.Long, "client-server system", "long description should mention client-server system")
+
+	// Check some expected subcommands are registered
+	subCommands := rootCmd.Commands()
+	var subCommandNames []string
+	for _, cmd := range subCommands {
+		subCommandNames = append(subCommandNames, cmd.Name())
+	}
+
+	expectedCommands := []string{
+		"register",
+		"login",
+		"add-bank-card",
+		"add-binary-secret",
+		"add-text-secret",
+		"add-username-password",
+		"get-secret",
+		"list-secrets",
+		"delete-secret",
+		"sync",
+	}
+
+	for _, expected := range expectedCommands {
+		assert.Contains(t, subCommandNames, expected, "should contain subcommand "+expected)
+	}
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"log"
+
+	"github.com/sbilibin2017/gophkeeper/cmd/client/app"
+)
+
+func main() {
+	cmd := app.NewRootCommand()
+
+	err := cmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/sbilibin2017/gophkeeper/pkg/grpc"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sbilibin2017/gophkeeper/internal/models"
+)
+
+// AuthHTTP sends an HTTP authentication request using models.AuthRequest and models.AuthResponse.
+// It posts the request to the "/auth" endpoint (update this path to match your actual API).
+//
+// Returns the AuthResponse containing the authentication token if successful,
+// or an error if the request failed or the status code is not 200.
+func AuthHTTP(
+	ctx context.Context,
+	client *resty.Client,
+	req *models.AuthRequest,
+) (*models.AuthResponse, error) {
+	resp := &models.AuthResponse{}
+
+	httpResp, err := client.R().
+		SetContext(ctx).
+		SetBody(req).
+		SetResult(resp).
+		Post("/auth")
+	if err != nil {
+		return nil, fmt.Errorf("failed to send HTTP auth request: %w", err)
+	}
+
+	if httpResp.StatusCode() != 200 {
+		return nil, fmt.Errorf("auth failed with status %d: %s", httpResp.StatusCode(), httpResp.String())
+	}
+
+	return resp, nil
+}
+
+// AuthGRPC calls the Auth method of the gRPC AuthService using protobuf request and response.
+// It converts the models.AuthRequest to protobuf.AuthRequest,
+// calls the service, and then converts the protobuf.AuthResponse back to models.AuthResponse.
+//
+// Returns the AuthResponse containing the authentication token if successful,
+// or an error if the gRPC call failed.
+func AuthGRPC(
+	ctx context.Context,
+	client pb.AuthServiceClient,
+	req *models.AuthRequest,
+) (*models.AuthResponse, error) {
+	pbReq := &pb.AuthRequest{
+		Username: req.Username,
+		Password: req.Password,
+	}
+
+	pbResp, err := client.Auth(ctx, pbReq)
+	if err != nil {
+		return nil, fmt.Errorf("grpc auth call failed: %w", err)
+	}
+
+	resp := &models.AuthResponse{
+		Token: pbResp.Token,
+	}
+
+	return resp, nil
+}

--- a/internal/client/auth_test.go
+++ b/internal/client/auth_test.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sbilibin2017/gophkeeper/internal/models"
+	pb "github.com/sbilibin2017/gophkeeper/pkg/grpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// --- HTTP server for tests ---
+
+func authRunTestHTTPServer(t *testing.T) (*http.Server, string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth", func(w http.ResponseWriter, r *http.Request) {
+		var req models.AuthRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		resp := models.AuthResponse{Token: "test-token-for-" + req.Username}
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(resp)
+		require.NoError(t, err)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{Handler: mux}
+
+	go func() {
+		err := srv.Serve(listener)
+		if err != nil && err != http.ErrServerClosed {
+			t.Errorf("HTTP server error: %v", err)
+		}
+	}()
+
+	return srv, listener.Addr().String()
+}
+
+// --- gRPC server for tests ---
+
+const authBufSize = 1024 * 1024
+
+type authTestAuthServer struct {
+	pb.UnimplementedAuthServiceServer
+}
+
+func (s *authTestAuthServer) Auth(ctx context.Context, req *pb.AuthRequest) (*pb.AuthResponse, error) {
+	return &pb.AuthResponse{Token: "test-token-for-" + req.Username}, nil
+}
+
+func authRunTestGRPCServer(t *testing.T) (*grpc.Server, *bufconn.Listener) {
+	listener := bufconn.Listen(authBufSize)
+	grpcServer := grpc.NewServer()
+	pb.RegisterAuthServiceServer(grpcServer, &authTestAuthServer{})
+
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil {
+			t.Errorf("gRPC server error: %v", err)
+		}
+	}()
+
+	return grpcServer, listener
+}
+
+// Dialer for bufconn gRPC client
+func authBufDialer(listener *bufconn.Listener) func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, _ string) (net.Conn, error) {
+		return listener.Dial()
+	}
+}
+
+// --- Tests ---
+
+func TestAuthHTTP(t *testing.T) {
+	srv, addr := authRunTestHTTPServer(t)
+	defer srv.Close()
+
+	client := resty.New()
+	client.SetBaseURL("http://" + addr)
+
+	ctx := context.Background()
+	req := &models.AuthRequest{Username: "user1", Password: "pass"}
+
+	resp, err := AuthHTTP(ctx, client, req)
+	require.NoError(t, err)
+	require.Equal(t, "test-token-for-user1", resp.Token)
+}
+
+func TestAuthGRPC(t *testing.T) {
+	grpcServer, listener := authRunTestGRPCServer(t)
+	defer grpcServer.Stop()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet",
+		grpc.WithContextDialer(authBufDialer(listener)), // bufconn dialer
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	grpcClient := pb.NewAuthServiceClient(conn)
+	req := &models.AuthRequest{Username: "user1", Password: "pass"}
+
+	resp, err := AuthGRPC(ctx, grpcClient, req)
+	require.NoError(t, err)
+	require.Equal(t, "test-token-for-user1", resp.Token)
+}

--- a/internal/configs/client.go
+++ b/internal/configs/client.go
@@ -60,12 +60,9 @@ func WithClientConfigGRPCClient(addr string, grpcOpts ...clients.GRPCClientOptio
 }
 
 // WithClientConfigDB connects to a database using the specified driver and DSN.
-func WithClientConfigDB(dsn string) ClientConfigOpt {
+func WithClientConfigDB() ClientConfigOpt {
 	return func(cfg *ClientConfig) error {
-		if dsn == "" {
-			return nil
-		}
-		conn, err := db.NewDB("sqlite", dsn)
+		conn, err := db.NewDB("sqlite", "client.db")
 		if err != nil {
 			return err
 		}

--- a/internal/configs/client.go
+++ b/internal/configs/client.go
@@ -60,12 +60,12 @@ func WithClientConfigGRPCClient(addr string, grpcOpts ...clients.GRPCClientOptio
 }
 
 // WithClientConfigDB connects to a database using the specified driver and DSN.
-func WithClientConfigDB(driver, dsn string) ClientConfigOpt {
+func WithClientConfigDB(dsn string) ClientConfigOpt {
 	return func(cfg *ClientConfig) error {
 		if dsn == "" {
 			return nil
 		}
-		conn, err := db.NewDB(driver, dsn)
+		conn, err := db.NewDB("sqlite", dsn)
 		if err != nil {
 			return err
 		}

--- a/internal/configs/client.go
+++ b/internal/configs/client.go
@@ -1,0 +1,90 @@
+package configs
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/jmoiron/sqlx"
+	"github.com/sbilibin2017/gophkeeper/internal/configs/clients"
+	"github.com/sbilibin2017/gophkeeper/internal/configs/db"
+	"google.golang.org/grpc"
+)
+
+// ClientConfig holds client configuration including HTTP client, gRPC client, and database connection.
+type ClientConfig struct {
+	HTTPClient *resty.Client
+	GRPCClient *grpc.ClientConn
+	DB         *sqlx.DB
+}
+
+// ClientConfigOpt defines a function type for applying options to ClientConfig.
+type ClientConfigOpt func(*ClientConfig) error
+
+// NewClientConfig creates a new ClientConfig and applies the provided options.
+func NewClientConfig(opts ...ClientConfigOpt) (*ClientConfig, error) {
+	cfg := &ClientConfig{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+// WithClientConfigHTTPClient creates an HTTP client with the first non-empty baseURL and optional HTTP client options.
+func WithClientConfigHTTPClient(baseURL string, httpOpts ...clients.HTTPClientOption) ClientConfigOpt {
+	return func(cfg *ClientConfig) error {
+		if baseURL == "" {
+			return nil
+		}
+		client, err := clients.NewHTTPClient(baseURL, httpOpts...)
+		if err != nil {
+			return err
+		}
+		cfg.HTTPClient = client
+		return nil
+	}
+}
+
+// WithClientConfigGRPCClient creates a gRPC client with the given non-empty address and optional gRPC client options.
+func WithClientConfigGRPCClient(addr string, grpcOpts ...clients.GRPCClientOption) ClientConfigOpt {
+	return func(cfg *ClientConfig) error {
+		if addr == "" {
+			return nil
+		}
+		conn, err := clients.NewGRPCClient(addr, grpcOpts...)
+		if err != nil {
+			return err
+		}
+		cfg.GRPCClient = conn
+		return nil
+	}
+}
+
+// WithClientConfigDB connects to a database using the specified driver and DSN.
+func WithClientConfigDB(driver, dsn string) ClientConfigOpt {
+	return func(cfg *ClientConfig) error {
+		if dsn == "" {
+			return nil
+		}
+		conn, err := db.NewDB(driver, dsn)
+		if err != nil {
+			return err
+		}
+		cfg.DB = conn
+		return nil
+	}
+}
+
+// WithClientConfigDBWithMigrations connects to a SQLite database with the provided DSN and applies migrations.
+func WithClientConfigDBWithMigrations(dsn string) ClientConfigOpt {
+	return func(cfg *ClientConfig) error {
+		if dsn == "" {
+			return nil
+		}
+		conn, err := db.NewDB("sqlite", dsn)
+		if err != nil {
+			return err
+		}
+		cfg.DB = conn
+		return nil
+	}
+}

--- a/internal/configs/client_test.go
+++ b/internal/configs/client_test.go
@@ -60,7 +60,7 @@ func TestNewClientConfig(t *testing.T) {
 	t.Run("With DB connection", func(t *testing.T) {
 		// Используем SQLite in-memory БД
 		cfg, err := NewClientConfig(
-			WithClientConfigDB("sqlite", "file::memory:?cache=shared"),
+			WithClientConfigDB("file::memory:?cache=shared"),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, cfg.DB)
@@ -71,7 +71,7 @@ func TestNewClientConfig(t *testing.T) {
 
 	t.Run("With empty DB dsn", func(t *testing.T) {
 		cfg, err := NewClientConfig(
-			WithClientConfigDB("sqlite", ""),
+			WithClientConfigDB(""),
 		)
 		require.NoError(t, err)
 		assert.Nil(t, cfg.DB)

--- a/internal/configs/client_test.go
+++ b/internal/configs/client_test.go
@@ -1,0 +1,95 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientConfig(t *testing.T) {
+	t.Run("Empty config", func(t *testing.T) {
+		cfg, err := NewClientConfig()
+		require.NoError(t, err)
+		assert.Nil(t, cfg.HTTPClient)
+		assert.Nil(t, cfg.GRPCClient)
+		assert.Nil(t, cfg.DB)
+	})
+
+	t.Run("With HTTP Client", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigHTTPClient("https://example.com"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.HTTPClient)
+		assert.IsType(t, &resty.Client{}, cfg.HTTPClient)
+		assert.Equal(t, "https://example.com", cfg.HTTPClient.BaseURL)
+	})
+
+	t.Run("With empty HTTP baseURL", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigHTTPClient(""),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.HTTPClient)
+	})
+
+	t.Run("With gRPC Client", func(t *testing.T) {
+		// Используем localhost:0, чтобы не ожидать реального сервера, соединение может упасть, но тест проверит ошибку
+		cfg, err := NewClientConfig(
+			WithClientConfigGRPCClient("localhost:0"),
+		)
+		// Ошибка подключения ожидаема, так как сервера нет — проверим, что err != nil и GRPCClient == nil
+		if err != nil {
+			assert.Nil(t, cfg)
+		} else {
+			require.NotNil(t, cfg.GRPCClient)
+			_ = cfg.GRPCClient.Close()
+		}
+	})
+
+	t.Run("With empty gRPC address", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigGRPCClient(""),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.GRPCClient)
+	})
+
+	t.Run("With DB connection", func(t *testing.T) {
+		// Используем SQLite in-memory БД
+		cfg, err := NewClientConfig(
+			WithClientConfigDB("sqlite", "file::memory:?cache=shared"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DB)
+		var version string
+		err = cfg.DB.Get(&version, "select sqlite_version()")
+		assert.NoError(t, err)
+	})
+
+	t.Run("With empty DB dsn", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigDB("sqlite", ""),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.DB)
+	})
+
+	t.Run("With DB With Migrations", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigDBWithMigrations("file::memory:?cache=shared"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DB)
+	})
+
+	t.Run("With empty DSN With Migrations", func(t *testing.T) {
+		cfg, err := NewClientConfig(
+			WithClientConfigDBWithMigrations(""),
+		)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.DB)
+	})
+}

--- a/internal/configs/clients/grpc.go
+++ b/internal/configs/clients/grpc.go
@@ -1,0 +1,114 @@
+package clients
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+// GRPCClientOption defines a function type to configure grpc.DialOption.
+type GRPCClientOption func(*grpcDialOptions) error
+
+type grpcDialOptions struct {
+	dialOpts []grpc.DialOption
+}
+
+// WithGRPCKeepaliveParams sets the keepalive parameters for the gRPC client.
+// Parameters:
+// - params: keepalive.ClientParameters struct specifying the keepalive settings.
+// Returns:
+// - a GRPCClientOption function to apply the keepalive parameters.
+func WithGRPCKeepaliveParams(params keepalive.ClientParameters) GRPCClientOption {
+	return func(opts *grpcDialOptions) error {
+		opts.dialOpts = append(opts.dialOpts, grpc.WithKeepaliveParams(params))
+		return nil
+	}
+}
+
+// WithGRPCTransportCredentials sets the transport credentials for the gRPC client.
+// Parameters:
+// - creds: transport credentials (e.g., TLS credentials).
+// Returns:
+// - a GRPCClientOption function to apply the transport credentials.
+func WithGRPCTransportCredentials(creds credentials.TransportCredentials) GRPCClientOption {
+	return func(opts *grpcDialOptions) error {
+		opts.dialOpts = append(opts.dialOpts, grpc.WithTransportCredentials(creds))
+		return nil
+	}
+}
+
+// WithGRPCTLSClientCert loads a client TLS certificate and private key, then configures the client with them.
+// Parameters:
+// - certFile: path to the client certificate file.
+// - keyFile: path to the client private key file.
+// Returns:
+// - a GRPCClientOption function that applies the TLS client cert.
+// - an error if loading the certificate or key fails.
+func WithGRPCTLSClientCert(certFile, keyFile string) GRPCClientOption {
+	return func(opts *grpcDialOptions) error {
+		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return fmt.Errorf("failed to load client certificate/key: %w", err)
+		}
+
+		// Load system root CA pool
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			rootCAs = x509.NewCertPool()
+		}
+
+		// Create TLS config with client cert and root CAs
+		tlsConfig := &tls.Config{
+			Certificates: []tls.Certificate{certificate},
+			RootCAs:      rootCAs,
+		}
+
+		creds := credentials.NewTLS(tlsConfig)
+		opts.dialOpts = append(opts.dialOpts, grpc.WithTransportCredentials(creds))
+		return nil
+	}
+}
+
+// NewGRPCClient creates a new gRPC client connection to the specified target with optional configurations.
+// Default options include:
+// - insecure transport credentials (if not overridden)
+// - keepalive parameters set to 10s interval, 3s timeout, and permit without stream enabled.
+// Parameters:
+// - target: the server address to connect to.
+// - opts: optional GRPCClientOption functions to customize the client connection.
+// Returns:
+// - a grpc.ClientConn instance.
+// - an error if the connection fails.
+func NewGRPCClient(target string, opts ...GRPCClientOption) (*grpc.ClientConn, error) {
+	options := &grpcDialOptions{}
+
+	// Set default dial options
+	options.dialOpts = append(options.dialOpts,
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                10 * time.Second,
+			Timeout:             3 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+
+	// Apply user options that can override defaults
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			return nil, err
+		}
+	}
+
+	conn, err := grpc.NewClient(target, options.dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/internal/configs/clients/grpc.go
+++ b/internal/configs/clients/grpc.go
@@ -20,10 +20,6 @@ type grpcDialOptions struct {
 }
 
 // WithGRPCKeepaliveParams sets the keepalive parameters for the gRPC client.
-// Parameters:
-// - params: keepalive.ClientParameters struct specifying the keepalive settings.
-// Returns:
-// - a GRPCClientOption function to apply the keepalive parameters.
 func WithGRPCKeepaliveParams(params keepalive.ClientParameters) GRPCClientOption {
 	return func(opts *grpcDialOptions) error {
 		opts.dialOpts = append(opts.dialOpts, grpc.WithKeepaliveParams(params))
@@ -32,10 +28,6 @@ func WithGRPCKeepaliveParams(params keepalive.ClientParameters) GRPCClientOption
 }
 
 // WithGRPCTransportCredentials sets the transport credentials for the gRPC client.
-// Parameters:
-// - creds: transport credentials (e.g., TLS credentials).
-// Returns:
-// - a GRPCClientOption function to apply the transport credentials.
 func WithGRPCTransportCredentials(creds credentials.TransportCredentials) GRPCClientOption {
 	return func(opts *grpcDialOptions) error {
 		opts.dialOpts = append(opts.dialOpts, grpc.WithTransportCredentials(creds))
@@ -44,12 +36,6 @@ func WithGRPCTransportCredentials(creds credentials.TransportCredentials) GRPCCl
 }
 
 // WithGRPCTLSClientCert loads a client TLS certificate and private key, then configures the client with them.
-// Parameters:
-// - certFile: path to the client certificate file.
-// - keyFile: path to the client private key file.
-// Returns:
-// - a GRPCClientOption function that applies the TLS client cert.
-// - an error if loading the certificate or key fails.
 func WithGRPCTLSClientCert(certFile, keyFile string) GRPCClientOption {
 	return func(opts *grpcDialOptions) error {
 		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
@@ -57,13 +43,11 @@ func WithGRPCTLSClientCert(certFile, keyFile string) GRPCClientOption {
 			return fmt.Errorf("failed to load client certificate/key: %w", err)
 		}
 
-		// Load system root CA pool
 		rootCAs, err := x509.SystemCertPool()
 		if err != nil {
 			rootCAs = x509.NewCertPool()
 		}
 
-		// Create TLS config with client cert and root CAs
 		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{certificate},
 			RootCAs:      rootCAs,
@@ -76,15 +60,6 @@ func WithGRPCTLSClientCert(certFile, keyFile string) GRPCClientOption {
 }
 
 // NewGRPCClient creates a new gRPC client connection to the specified target with optional configurations.
-// Default options include:
-// - insecure transport credentials (if not overridden)
-// - keepalive parameters set to 10s interval, 3s timeout, and permit without stream enabled.
-// Parameters:
-// - target: the server address to connect to.
-// - opts: optional GRPCClientOption functions to customize the client connection.
-// Returns:
-// - a grpc.ClientConn instance.
-// - an error if the connection fails.
 func NewGRPCClient(target string, opts ...GRPCClientOption) (*grpc.ClientConn, error) {
 	options := &grpcDialOptions{}
 

--- a/internal/configs/clients/grpc_test.go
+++ b/internal/configs/clients/grpc_test.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -86,7 +85,7 @@ func TestNewGRPCClient(t *testing.T) {
 	})
 
 	t.Run("With custom transport credentials", func(t *testing.T) {
-		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
+		creds := credentials.NewTLS(nil) // nil config = default TLS config
 		conn, err := NewGRPCClient("localhost:50051",
 			WithGRPCTransportCredentials(creds),
 		)

--- a/internal/configs/clients/grpc_test.go
+++ b/internal/configs/clients/grpc_test.go
@@ -1,0 +1,97 @@
+package clients
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+)
+
+func generateSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		DNSNames: []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certOut := filepath.Join(dir, "cert.pem")
+	keyOut := filepath.Join(dir, "key.pem")
+
+	err = os.WriteFile(certOut, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644)
+	require.NoError(t, err)
+
+	keyBytes := x509.MarshalPKCS1PrivateKey(priv)
+	err = os.WriteFile(keyOut, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes}), 0644)
+	require.NoError(t, err)
+
+	return certOut, keyOut
+}
+
+func TestNewGRPCClient(t *testing.T) {
+	t.Run("With keepalive params", func(t *testing.T) {
+		conn, err := NewGRPCClient("localhost:50051",
+			WithGRPCKeepaliveParams(keepalive.ClientParameters{
+				Time:                20 * time.Second,
+				Timeout:             5 * time.Second,
+				PermitWithoutStream: true,
+			}),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		_ = conn.Close()
+	})
+
+	t.Run("With TLS client cert", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := generateSelfSignedCert(t, dir)
+
+		conn, err := NewGRPCClient("localhost:50051",
+			WithGRPCTLSClientCert(certPath, keyPath),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		_ = conn.Close()
+	})
+
+	t.Run("Invalid TLS cert path", func(t *testing.T) {
+		_, err := NewGRPCClient("localhost:50051",
+			WithGRPCTLSClientCert("bad_cert_path.pem", "bad_key_path.pem"),
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("With custom transport credentials", func(t *testing.T) {
+		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
+		conn, err := NewGRPCClient("localhost:50051",
+			WithGRPCTransportCredentials(creds),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, conn)
+		_ = conn.Close()
+	})
+}

--- a/internal/configs/clients/http.go
+++ b/internal/configs/clients/http.go
@@ -1,0 +1,101 @@
+package clients
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// HTTPClientOption defines a function type for configuring a Resty client.
+type HTTPClientOption func(*resty.Client) error
+
+// WithHTTPTLSServerCert добавляет доверенный серверный сертификат (public CA) для TLS.
+// certFile — путь к публичному сертификату сервера.
+func WithHTTPTLSServerCert(certFile string) HTTPClientOption {
+	return func(client *resty.Client) error {
+		// Читаем сертификат сервера
+		caCert, err := os.ReadFile(certFile)
+		if err != nil {
+			return fmt.Errorf("failed to read server cert file: %w", err)
+		}
+
+		// Создаем новый пул корневых сертификатов и добавляем туда серверный сертификат
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caCert) {
+			return fmt.Errorf("failed to append server cert to pool")
+		}
+
+		tlsConfig := &tls.Config{
+			RootCAs: caPool,
+		}
+
+		client.SetTLSClientConfig(tlsConfig)
+		return nil
+	}
+}
+
+// WithHTTPRetryCount sets the number of retry attempts for HTTP requests.
+// Parameters:
+// - count: the retry count.
+// Returns:
+// - a HTTPClientOption function that configures the retry count.
+func WithHTTPRetryCount(count int) HTTPClientOption {
+	return func(client *resty.Client) error {
+		client.SetRetryCount(count)
+		return nil
+	}
+}
+
+// WithHTTPRetryWaitTime sets the minimum wait time between retries.
+// Parameters:
+// - d: duration to wait before retrying.
+// Returns:
+// - a HTTPClientOption function that configures the retry wait time.
+func WithHTTPRetryWaitTime(d time.Duration) HTTPClientOption {
+	return func(client *resty.Client) error {
+		client.SetRetryWaitTime(d)
+		return nil
+	}
+}
+
+// WithHTTPRetryMaxWaitTime sets the maximum wait time between retries.
+// Parameters:
+// - d: maximum duration to wait before retrying.
+// Returns:
+// - a HTTPClientOption function that configures the max retry wait time.
+func WithHTTPRetryMaxWaitTime(d time.Duration) HTTPClientOption {
+	return func(client *resty.Client) error {
+		client.SetRetryMaxWaitTime(d)
+		return nil
+	}
+}
+
+// NewHTTPClient creates a new Resty client with the base URL and optional configurations.
+// It sets default values for retry attempts and wait times before applying custom options.
+// Parameters:
+// - baseURL: the base URL for the HTTP client.
+// - opts: optional HTTPClientOption functions to customize the client.
+// Returns:
+// - a configured *resty.Client instance.
+// - an error if any option fails to apply.
+func NewHTTPClient(baseURL string, opts ...HTTPClientOption) (*resty.Client, error) {
+	client := resty.New().SetBaseURL(baseURL)
+
+	// Default values
+	client.SetRetryCount(3)
+	client.SetRetryWaitTime(500 * time.Millisecond)
+	client.SetRetryMaxWaitTime(2 * time.Second)
+
+	// Apply custom options which can override defaults
+	for _, opt := range opts {
+		if err := opt(client); err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}

--- a/internal/configs/clients/http_test.go
+++ b/internal/configs/clients/http_test.go
@@ -1,0 +1,140 @@
+package clients
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestCACert(t *testing.T, path string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certOut, err := os.Create(path)
+	require.NoError(t, err)
+	defer certOut.Close()
+
+	require.NoError(t, pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}))
+}
+
+func TestNewHTTPClient(t *testing.T) {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "ca.crt")
+
+	generateTestCACert(t, certPath)
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		options     []HTTPClientOption
+		expectError bool
+		assertFn    func(t *testing.T, c *resty.Client)
+	}{
+		{
+			name:    "Default client",
+			baseURL: "http://localhost",
+			assertFn: func(t *testing.T, c *resty.Client) {
+				assert.Equal(t, 3, c.RetryCount)
+				assert.Equal(t, 500*time.Millisecond, c.RetryWaitTime)
+				assert.Equal(t, 2*time.Second, c.RetryMaxWaitTime)
+				assert.Equal(t, "http://localhost", c.BaseURL)
+			},
+		},
+		{
+			name:    "Custom retry count",
+			baseURL: "http://localhost",
+			options: []HTTPClientOption{
+				WithHTTPRetryCount(5),
+			},
+			assertFn: func(t *testing.T, c *resty.Client) {
+				assert.Equal(t, 5, c.RetryCount)
+			},
+		},
+		{
+			name:    "Custom retry wait time",
+			baseURL: "http://localhost",
+			options: []HTTPClientOption{
+				WithHTTPRetryWaitTime(1 * time.Second),
+			},
+			assertFn: func(t *testing.T, c *resty.Client) {
+				assert.Equal(t, 1*time.Second, c.RetryWaitTime)
+			},
+		},
+		{
+			name:    "Custom max retry wait time",
+			baseURL: "http://localhost",
+			options: []HTTPClientOption{
+				WithHTTPRetryMaxWaitTime(10 * time.Second),
+			},
+			assertFn: func(t *testing.T, c *resty.Client) {
+				assert.Equal(t, 10*time.Second, c.RetryMaxWaitTime)
+			},
+		},
+		{
+			name:    "Valid TLS cert",
+			baseURL: "https://localhost",
+			options: []HTTPClientOption{
+				WithHTTPTLSServerCert(certPath),
+			},
+			assertFn: func(t *testing.T, c *resty.Client) {
+				tlsCfg := c.GetClient().Transport.(*http.Transport).TLSClientConfig
+				assert.NotNil(t, tlsCfg)
+				assert.IsType(t, &tls.Config{}, tlsCfg)
+				assert.NotNil(t, tlsCfg.RootCAs)
+			},
+		},
+		{
+			name:    "Invalid TLS cert path",
+			baseURL: "https://localhost",
+			options: []HTTPClientOption{
+				WithHTTPTLSServerCert("nonexistent.crt"),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewHTTPClient(tt.baseURL, tt.options...)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+				if tt.assertFn != nil {
+					tt.assertFn(t, client)
+				}
+			}
+		})
+	}
+}

--- a/internal/configs/db/db.go
+++ b/internal/configs/db/db.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/pressly/goose/v3"
+	_ "modernc.org/sqlite"
+)
+
+// NewDB establishes a connection to the database and returns a sqlx.DB instance.
+// Parameters:
+// - driver: the database driver name (e.g., "sqlite").
+// - dsn: the data source name or connection string.
+// Returns:
+// - a pointer to sqlx.DB if successful.
+// - an error if connection fails.
+func NewDB(driver string, dsn string) (*sqlx.DB, error) {
+	db, err := sqlx.Connect(driver, dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// RunMigrations applies database migrations from the specified directory using goose.
+// Parameters:
+// - db: the sqlx.DB instance connected to the database.
+// - driver: the database driver name (e.g., "sqlite").
+// - pathToDir: the directory path containing migration files.
+// Returns:
+// - an error if migration setup or execution fails.
+func RunMigrations(db *sqlx.DB, driver string, pathToDir string) error {
+	if err := goose.SetDialect(driver); err != nil {
+		return err
+	}
+	if err := goose.Up(db.DB, pathToDir); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/configs/db/db_test.go
+++ b/internal/configs/db/db_test.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDB(t *testing.T) {
+	tests := []struct {
+		name      string
+		driver    string
+		dsn       string
+		shouldErr bool
+	}{
+		{
+			name:      "Valid SQLite in-memory",
+			driver:    "sqlite",
+			dsn:       "file::memory:?cache=shared",
+			shouldErr: false,
+		},
+		{
+			name:      "Invalid driver",
+			driver:    "invalid-driver",
+			dsn:       "file::memory:?cache=shared",
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbConn, err := NewDB(tt.driver, tt.dsn)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				assert.Nil(t, dbConn)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, dbConn)
+				_ = dbConn.Close()
+			}
+		})
+	}
+}
+
+func TestRunMigrations(t *testing.T) {
+	// Создаем временную директорию для миграций
+	tmpDir := t.TempDir()
+
+	// Создаем корректный SQL-файл с директивами goose
+	migrationFile := filepath.Join(tmpDir, "00001_create_table.sql")
+	err := os.WriteFile(migrationFile, []byte(`
+-- +goose Up
+CREATE TABLE test_table (
+	id INTEGER PRIMARY KEY,
+	name TEXT
+);
+
+-- +goose Down
+DROP TABLE test_table;
+`), 0644)
+	require.NoError(t, err)
+
+	dbConn, err := NewDB("sqlite", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	defer dbConn.Close()
+
+	t.Run("Run valid migration", func(t *testing.T) {
+		err := RunMigrations(dbConn, "sqlite", tmpDir)
+		assert.NoError(t, err)
+
+		var exists int
+		err = dbConn.Get(&exists, `SELECT count(*) FROM sqlite_master WHERE type='table' AND name='test_table'`)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, exists)
+	})
+
+	t.Run("Invalid path", func(t *testing.T) {
+		err := RunMigrations(dbConn, "sqlite", "/non/existing/path")
+		assert.Error(t, err)
+	})
+
+	t.Run("Unsupported dialect", func(t *testing.T) {
+		err := RunMigrations(dbConn, "invalid-dialect", tmpDir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown dialect")
+	})
+}

--- a/internal/configs/scheme/scheme.go
+++ b/internal/configs/scheme/scheme.go
@@ -1,0 +1,27 @@
+package scheme
+
+import "strings"
+
+const (
+	HTTP  = "http"
+	HTTPS = "https"
+	GRPC  = "grpc"
+)
+
+var schemeMap = map[string]string{
+	"http://":  HTTP,
+	"https://": HTTPS,
+	"grpc://":  GRPC,
+}
+
+// GetSchemeFromURL determines the protocol type by checking the prefix of the given URL.
+// It returns one of the predefined protocol constants ("http", "https", "grpc") if the prefix matches,
+// or an empty string if no known prefix is found.
+func GetSchemeFromURL(url string) string {
+	for prefix, scheme := range schemeMap {
+		if strings.HasPrefix(url, prefix) {
+			return scheme
+		}
+	}
+	return ""
+}

--- a/internal/configs/scheme/scheme_test.go
+++ b/internal/configs/scheme/scheme_test.go
@@ -1,0 +1,53 @@
+package scheme
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSchemeFromURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "HTTP scheme",
+			url:      "http://example.com",
+			expected: HTTP,
+		},
+		{
+			name:     "HTTPS scheme",
+			url:      "https://example.com",
+			expected: HTTPS,
+		},
+		{
+			name:     "gRPC scheme",
+			url:      "grpc://service.local",
+			expected: GRPC,
+		},
+		{
+			name:     "Unknown scheme",
+			url:      "ftp://example.com",
+			expected: "",
+		},
+		{
+			name:     "Empty string",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "Partial match",
+			url:      "httpx://malformed",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := GetSchemeFromURL(tt.url)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -1,0 +1,12 @@
+package models
+
+// AuthRequest represents an authentication request with username and password.
+type AuthRequest struct {
+	Username string `json:"username"` // Username for authentication
+	Password string `json:"password"` // Password for authentication
+}
+
+// AuthResponse represents an authentication response containing a token.
+type AuthResponse struct {
+	Token string `json:"token"` // JWT or authentication token
+}

--- a/internal/models/bank_card.go
+++ b/internal/models/bank_card.go
@@ -1,0 +1,33 @@
+package models
+
+// AddSecretBankCardRequest represents a request to add a bank card.
+type BankCardAddRequest struct {
+	SecretName string  `json:"secret_name"`    // Secret name
+	Number     string  `json:"number"`         // Card number
+	Owner      string  `json:"owner"`          // Card owner
+	Exp        string  `json:"exp"`            // Expiration date
+	CVV        string  `json:"cvv"`            // CVV code
+	Meta       *string `json:"meta,omitempty"` // Optional metadata
+}
+
+// GetSecretBankCardRequest represents a request to get a bank card.
+type BankCardGetRequest struct {
+	SecretName string `json:"secret_name"` // Secret name
+}
+
+// GetSecretBankCardResponse represents a response with bank card information.
+type BankCardResponse struct {
+	SecretName  string  `json:"secret_name"`    // Secret name
+	SecretOwner string  `json:"secret_owner"`   // Secret owner
+	Number      string  `json:"number"`         // Card number
+	Owner       string  `json:"owner"`          // Card owner
+	Exp         string  `json:"exp"`            // Expiration date
+	CVV         string  `json:"cvv"`            // CVV code
+	Meta        *string `json:"meta,omitempty"` // Optional metadata
+	UpdatedAt   string  `json:"updated_at"`     // Last update timestamp
+}
+
+// ListSecretBankCardResponse contains a list of bank cards.
+type BankCardListResponse struct {
+	Items []BankCardResponse `json:"items"` // List of bank cards
+}

--- a/internal/models/binary.go
+++ b/internal/models/binary.go
@@ -1,0 +1,27 @@
+package models
+
+// AddSecretBinaryRequest represents a request to add a binary secret.
+type AddSecretBinaryRequest struct {
+	SecretName string  `json:"secret_name"`    // Secret name
+	Data       []byte  `json:"data"`           // Binary data
+	Meta       *string `json:"meta,omitempty"` // Optional metadata
+}
+
+// GetSecretBinaryRequest represents a request to get a binary secret.
+type GetSecretBinaryRequest struct {
+	SecretName string `json:"secret_name"` // Secret name
+}
+
+// GetSecretBinaryResponse represents a response with a binary secret.
+type GetSecretBinaryResponse struct {
+	SecretName  string  `json:"secret_name"`    // Secret name
+	SecretOwner string  `json:"secret_owner"`   // Secret owner
+	Data        []byte  `json:"data"`           // Binary data
+	Meta        *string `json:"meta,omitempty"` // Optional metadata
+	UpdatedAt   string  `json:"updated_at"`     // Last update timestamp
+}
+
+// ListSecretBinaryResponse contains a list of binary secrets.
+type ListSecretBinaryResponse struct {
+	Items []GetSecretBinaryResponse `json:"items"` // List of binary secrets
+}

--- a/internal/models/text.go
+++ b/internal/models/text.go
@@ -1,0 +1,27 @@
+package models
+
+// TextAddRequest represents a request to add a text secret.
+type TextAddRequest struct {
+	SecretName string  `json:"secret_name"`    // Secret name
+	Content    string  `json:"content"`        // Text content
+	Meta       *string `json:"meta,omitempty"` // Optional metadata
+}
+
+// TextGetRequest represents a request to get a text secret.
+type TextGetRequest struct {
+	SecretName string `json:"secret_name"` // Secret name
+}
+
+// TextResponse represents a response with text secret information.
+type TextResponse struct {
+	SecretName  string  `json:"secret_name"`    // Secret name
+	SecretOwner string  `json:"secret_owner"`   // Secret owner
+	Content     string  `json:"content"`        // Text content
+	Meta        *string `json:"meta,omitempty"` // Optional metadata
+	UpdatedAt   string  `json:"updated_at"`     // Last update timestamp
+}
+
+// TextListResponse contains a list of text secrets.
+type TextListResponse struct {
+	Items []TextResponse `json:"items"` // List of text secrets
+}

--- a/internal/models/username_password.go
+++ b/internal/models/username_password.go
@@ -1,0 +1,29 @@
+package models
+
+// UsernamePasswordAddRequest represents a request to add a username-password secret.
+type UsernamePasswordAddRequest struct {
+	SecretName string  `json:"secret_name"`    // Secret name
+	Username   string  `json:"username"`       // Username
+	Password   string  `json:"password"`       // Password
+	Meta       *string `json:"meta,omitempty"` // Optional metadata
+}
+
+// UsernamePasswordGetRequest represents a request to get a username-password secret.
+type UsernamePasswordGetRequest struct {
+	SecretName string `json:"secret_name"` // Secret name
+}
+
+// UsernamePasswordResponse represents a response with a username-password secret.
+type UsernamePasswordResponse struct {
+	SecretName  string  `json:"secret_name"`    // Secret name
+	SecretOwner string  `json:"secret_owner"`   // Secret owner
+	Username    string  `json:"username"`       // Username
+	Password    string  `json:"password"`       // Password
+	Meta        *string `json:"meta,omitempty"` // Optional metadata
+	UpdatedAt   string  `json:"updated_at"`     // Last update timestamp
+}
+
+// UsernamePasswordListResponse contains a list of username-password secrets.
+type UsernamePasswordListResponse struct {
+	Items []UsernamePasswordResponse `json:"items"` // List of username-password secrets
+}


### PR DESCRIPTION
Этот ПР содержит исправления замечаний по предыдущему (ревью https://github.com/sbilibin2017/gophkeeper/pull/6) 

# На что стоит обратить внимание:

- [x] На мой взгляд, в cmd попало довольно много логики, которой место в internal в отдельном пакете
- [ ] Можно при желании углубиться в подход i18n и сделать мультиязычную поддержку (см комментарий в пр)
- [ ] Не до конца понял, как будет осуществляться шифрование
- [ ] Поддержка оффлайн режима и разрешение конфликтов, когда данные были добавлены на разных девайсах и прилетели с сервера ввиде апдейта
